### PR TITLE
Speakers URL no longer under People

### DIFF
--- a/resources/lib/model/speakers_scraper.py
+++ b/resources/lib/model/speakers_scraper.py
@@ -2,7 +2,7 @@ import html5lib
 
 from .url_constants import URLTED
 
-__url_speakers__ = URLTED + '/people/speakers?page=%s'
+__url_speakers__ = URLTED + '/speakers?page=%s'
 
 class Speakers:
 


### PR DESCRIPTION
Original URL now always pull speakers from page 1 regardless the chosen page range because the TED website URL now has no /people before /speakers.